### PR TITLE
rubocopから出ている警告を消す

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -8,10 +8,6 @@ AllCops:
 Rails:
   Enabled: true
 
-# Rails5になるまでfalse
-Rails/ApplicationRecord:
-  Enabled: false
-
 Style/AndOr:
   Enabled: true
 
@@ -94,10 +90,6 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 20
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*'
 
 Performance/RedundantBlockCall:
   Enabled: false

--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -43,16 +43,16 @@ Style/SingleLineBlockParams:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Layout/EmptyLinesAroundClassBody:
+Style/EmptyLinesAroundClassBody:
   Enabled: false
 
-Layout/EmptyLinesAroundModuleBody:
+Style/EmptyLinesAroundModuleBody:
   Enabled: false
 
-Layout/EmptyLinesAroundBlockBody:
+Style/EmptyLinesAroundBlockBody:
   Enabled: false
 
-Layout/EmptyLinesAroundMethodBody:
+Style/EmptyLinesAroundMethodBody:
   Enabled: true
 
 Style/EmptyCaseCondition:
@@ -80,10 +80,10 @@ Style/FrozenStringLiteralComment:
 Style/MutableConstant:
   Enabled: false
 
-Layout/MultilineOperationIndentation:
+Style/MultilineOperationIndentation:
   EnforcedStyle: indented
 
-Layout/MultilineMethodCallIndentation:
+Style/MultilineMethodCallIndentation:
   Enabled: false
 
 Metrics/LineLength:


### PR DESCRIPTION
#### 以下の項目は低いバージョンには存在しなかったので削除

- Rails/ApplicationRecord
- Metrics/BlockLength
