### PR TITLE
deprecatedなスタイル名を変更

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -21,7 +21,10 @@ Style/GlobalVars:
 Style/ClassVars:
   Enabled: true
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
手元でrubocop走らせるとエラー出たので
```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
```

rubyのバージョン上がってrubocopも上がった？
```
rubocop -v
0.57.2
```