### PR TITLE
制約をcomma → consistent_comma に変更

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -22,13 +22,13 @@ Style/ClassVars:
   Enabled: true
 
 Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma
 
 Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma
 
 Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma
 
 Style/AsciiComments:
   Enabled: false


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInArguments

consistent_commaにすることで、以下が許されるようになります。

```
arr = [
  a1, a2, a3,
  b1, b2, b3,
]
```

commaだと以下しか許容されません。

```
arr = [
  a1,
  a2,
  a3,
  b1,
  b2,
  b3,
]
```