### PR TITLE
RescueModifierをspec内では無視する

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -82,6 +82,10 @@ Style/FrozenStringLiteralComment:
 Style/MutableConstant:
   Enabled: false
 
+Style/RescueModifier:
+  Exclude:
+    - 'spec/**/*'
+
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 


### PR DESCRIPTION
- 以下の制約をspec内では無視します
  - https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RescueModifier
- 理由としては以下の通り

#### 1. そもそもテストコード内で例外を補足するようなことはなさそう

#### 2. 握りつぶしたい場合がある

以下のように `subject` 内部でわざと例外を発生させるコードを書いた際に、何もしないとテストそのものでRuntimeErrorが発生してしまうので、握りつぶす

```rb
allow(Hoge).to receive(:foo).and_raise
subject rescue nil
```
