### PR TITLE
add forbid_for_equality_operators_only

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -88,6 +88,9 @@ Layout/MultilineOperationIndentation:
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 
+Style/YodaCondition:
+  EnforcedStyle: forbid_for_equality_operators_only
+
 Metrics/LineLength:
   Enabled: false
 


### PR DESCRIPTION
## Subjective
allow YodaCondition like
```ruby
raise ArgumentError unless 0 <= foo && foo < 10
```

cf. https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/YodaCondition

## Preconditions
- `forbid_for_equality_operators_only` requires [rubocop v0.63.0+](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0630-2019-01-16)
- Therefore **ALL** of our repositories refering `.rubocop_common.yml` should be updated to rubocop v0.63.0+ **BEFORE** merging this PR