### PR TITLE
ignore Metrics/BlockLength for ActiveAdmin DSLs

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -100,6 +100,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+    - 'app/admin/*'
 
 Naming/HeredocDelimiterNaming:
   Enabled: false


### PR DESCRIPTION
ActiveAdmin DSL tends to become much longer; so exclude `app/admin/*` for `Metrics/BlockLength`