### PR TITLE
allow brackets for SymbolArray/WordArray

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -107,6 +107,14 @@ Style/SignalException:
 Style/SingleLineBlockParams:
   Enabled: false
 
+Style/SymbolArray:
+  EnforcedStyle: percent
+  MinSize: 10
+
+Style/WordArray:
+  EnforcedStyle: percent
+  MinSize: 10
+
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma
 


### PR DESCRIPTION
- https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/SymbolArray
- https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/WordArray