### PR TITLE
Style/NumericPredicate を無効化する

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -126,3 +126,6 @@ Style/TrailingCommaInHashLiteral:
 
 Style/YodaCondition:
   EnforcedStyle: forbid_for_equality_operators_only
+
+Style/NumericPredicate:
+  Enabled: false


### PR DESCRIPTION
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericPredicate
  - `positive?` `negative?` などは個人の好みの問題で、特に rubocop で指摘する必要はないと判断したため無効化
