### PR TITLE
set max line length

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -32,7 +32,7 @@ Metrics/BlockLength:
     - 'app/admin/*'
 
 Metrics/LineLength:
-  Enabled: false
+  Max: 120
 
 Metrics/MethodLength:
   Max: 25


### PR DESCRIPTION
IfUnlessModifierが無制限に後置ifを警告してくるので、長さ制限を有効にしました。

リファレンス
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfUnlessModifier