### PR TITLE
RspecにおいてはAmbiguousBlockAssociationを除外する

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -25,7 +25,7 @@ Layout/MultilineOperationIndentation:
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
-    - "spec/**/*"
+    - 'spec/**/*'
 
 Metrics/AbcSize:
   Max: 20

--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -23,6 +23,10 @@ Layout/MultilineMethodCallIndentation:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 Metrics/AbcSize:
   Max: 20
 


### PR DESCRIPTION
例えば、Rspec において自然な記法である以下のような記述を指摘されるのは面倒です。
特にRspecでは頻出するパターンなのでExcludeして対応します。

```ruby
expect do
  …
end.to_not change { Media.count }
```