### PR TITLE
app/api/ 配下では BlockLength を無視する

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -34,6 +34,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - 'app/admin/*'
+    - 'app/api/**/*'
 
 Metrics/LineLength:
   Enabled: false


### PR DESCRIPTION
T/O