### PR TITLE
enable Rails/TimeZone cop with strict

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -57,6 +57,9 @@ Rails/ApplicationRecord:
 Rails/Delegate:
   EnforceForPrefixed: false
 
+Rails/TimeZone:
+  EnforcedStyle: strict
+
 Rails/UnknownEnv:
   Environments:
     - production


### PR DESCRIPTION
changes
--
- enable `Rails/TimeZone` with **strict** 36aa34e
  - https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstimezone

reason
--
Time.current は Time.zone.now から Time.now にフォールバックする仕様が含まれているため strict で禁止にしたい
- https://apidock.com/rails/Time/current/class