### PR TITLE
メトリクス系の条件を緩和する

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -28,19 +28,23 @@ Lint/AmbiguousBlockAssociation:
     - 'spec/**/*'
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 30
 
 Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*'
-    - 'app/admin/*'
-    - 'app/api/**/*'
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
 
 Metrics/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
   Max: 25
+
+Metrics/ParameterLists:
+  Exclude:
+    - 'lib/**/*'
 
 Naming/HeredocDelimiterNaming:
   Enabled: false


### PR DESCRIPTION
# 概要

- メトリクス系の条件を、現実的なものに緩和する
- 現状、実質無視されてしまっている条件などもあったので、その対応

# メモ

- 複雑度に関わるもの ( `Metrics/CyclomaticComplexity` など ) も、ABCサイズと同じ用に緩和してもいいのかもしれませんが、自分はこれらを無効化したことは直近ない気がするので、一旦そのままにしてます
- これは不要であるとか、警告出たら普段無効化している、というのがある方はコメントください
