### PR TITLE
docker/ 以下を対象から除外する

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -4,6 +4,7 @@ AllCops:
     - 'db/**/*'
     - 'deploy/**/*'
     - 'vendor/**/*'
+    - 'docker/**/*'
 
 Layout/EmptyLinesAroundBlockBody:
   Enabled: false


### PR DESCRIPTION
# 概要

- `docker/` 以下は docker 起動中の tmp ファイルなども置かれているらしく、読み取り権限がなくて rubocop が失敗するので除外する

# 動作確認事項

- この設定ファイルを適用した状態で `bin/bundle exec rubocop` が実行できること
  - 適用前だとたぶんエラーになって死ぬ